### PR TITLE
proctor-builder: Fix option lookups by using short name

### DIFF
--- a/proctor-builder/src/main/java/com/indeed/proctor/builder/LocalProctorBuilder.java
+++ b/proctor-builder/src/main/java/com/indeed/proctor/builder/LocalProctorBuilder.java
@@ -40,7 +40,7 @@ public class LocalProctorBuilder extends ProctorBuilder {
         @Override
         protected void extract(CommandLine results)  {
             super.extract(results);
-            this.inputdir = results.getOptionValue("input");
+            this.inputdir = results.getOptionValue("i");
         }
 
         public String getInputdir() {

--- a/proctor-builder/src/main/java/com/indeed/proctor/builder/ProctorBuilderArgs.java
+++ b/proctor-builder/src/main/java/com/indeed/proctor/builder/ProctorBuilderArgs.java
@@ -68,14 +68,14 @@ class ProctorBuilderArgs {
 
 
     protected void extract(final CommandLine results) {
-        this.outputdir = results.getOptionValue("output", "-");
-        this.filename = results.getOptionValue("filename", "proctor-tests-matrix.json");
+        this.outputdir = results.getOptionValue("o", "-");
+        this.filename = results.getOptionValue("f", "proctor-tests-matrix.json");
 
-        if (results.hasOption("author")) {
-            this.author = results.getOptionValue("author");
+        if (results.hasOption("a")) {
+            this.author = results.getOptionValue("a");
         }
-        if (results.hasOption("version")) {
-            final String v = results.getOptionValue("version");
+        if (results.hasOption("v")) {
+            final String v = results.getOptionValue("v");
             if (v.length() > 0 && v.charAt(0) == 'r') { // support "svn-like" revisions like 'r149569'
                 this.version = Long.parseLong(v.substring(1));
             } else {


### PR DESCRIPTION
Hi folks,

I've been having trouble using proctor-builder to compile my set of test definitions into a single test matrix file. Any attempted to execute results in a NPE, as all of the options were being read as null

After debugging, I found that the code uses getOptionValue() and hasOptionValue() with the long option names, while the Apache cli library expects the short/character names:
http://commons.apache.org/proper/commons-cli/javadocs/api-1.1/index.html

With this small patch, I was able to generate my file successfully.

Thanks,
-Eloy Perez
eloyperez@homeaway.com
