### PR TITLE
fixed issue with force groups cookie getting cut off after a comma

### DIFF
--- a/proctor-consumer/src/main/java/com/indeed/proctor/consumer/ProctorConsumerUtils.java
+++ b/proctor-consumer/src/main/java/com/indeed/proctor/consumer/ProctorConsumerUtils.java
@@ -135,6 +135,7 @@ public class ProctorConsumerUtils {
 
         //  be sure to quote cookies because they have characters that are not allowed raw
         final StringBuilder sb = new StringBuilder(10*forceGroups.size());
+        sb.append('"');
         for (final Iterator<Entry<String, Integer>> iterator = forceGroups.entrySet().iterator(); iterator.hasNext(); ) {
             final Entry<String, Integer> next = iterator.next();
             sb.append(next.getKey()).append(next.getValue());
@@ -142,6 +143,7 @@ public class ProctorConsumerUtils {
                 sb.append(',');
             }
         }
+        sb.append('"');
 
         final String contextPath = request.getContextPath();
         final String cookiePath;


### PR DESCRIPTION
Cookies in ProctorConsumerUtils.setForcedGroupsCookie were not being stored with quotes so values would be cut off after a comma.
