### PR TITLE
Dependency cleanup for proctor artifacts.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,6 @@
         <version>14</version>
     </parent>
 
-    <groupId>com.indeed</groupId>
     <artifactId>proctor-parent</artifactId>
     <version>1.1.13-SNAPSHOT</version>
     <packaging>pom</packaging>
@@ -43,7 +42,29 @@
 
     <properties>
         <indeed-util.version>1.0.12</indeed-util.version>
-	    <apache-commons-pool2.version>2.2</apache-commons-pool2.version>
+        <apache-commons-pool2.version>2.2</apache-commons-pool2.version>
+        <commons-cli.version>1.2</commons-cli.version>
+        <jackson2.version>2.5.2</jackson2.version>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+                <version>${jackson2.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>${jackson2.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>util-varexport</artifactId>
+                <version>${indeed-util.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
 </project>

--- a/proctor-ant-plugin/pom.xml
+++ b/proctor-ant-plugin/pom.xml
@@ -26,7 +26,18 @@
             <artifactId>proctor-builder</artifactId>
             <version>${project.version}</version>
         </dependency>
-
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.apache.ant</groupId>
             <artifactId>ant</artifactId>

--- a/proctor-ant-plugin/src/main/java/com/indeed/proctor/consumer/gen/ant/TestGroupsGeneratorTask.java
+++ b/proctor-ant-plugin/src/main/java/com/indeed/proctor/consumer/gen/ant/TestGroupsGeneratorTask.java
@@ -66,14 +66,17 @@ public abstract class TestGroupsGeneratorTask extends Task {
      * Generates total specifications from any partial specifications found
      */
     protected void totalSpecificationGenerator(final File dir) throws CodeGenException {
-        if (dir.equals(null)) {
+        if (dir == null) {
             throw new CodeGenException("input directory creates null file");
         }
         final File[] providedContextFiles = dir.listFiles((java.io.FileFilter) FileFilterUtils.andFileFilter(FileFilterUtils.fileFileFilter(), FileFilterUtils.nameFileFilter("providedcontext.json")));
         if (providedContextFiles.length == 1) {
             //make directory if it doesn't exist
-            (new File(specificationOutput.substring(0,specificationOutput.lastIndexOf(File.separator)))).mkdirs();
             final File specificationOutputFile = new File(specificationOutput);
+            final File parent = specificationOutputFile.getParentFile();
+            if (!parent.isDirectory() && !parent.mkdirs()) {
+                throw new CodeGenException("Unable to create directory: " + parent.getPath());
+            }
             generateTotalSpecification(dir, specificationOutputFile);
         } else {
             throw new CodeGenException("Incorrect amount of providedcontext.json in specified input folder");
@@ -85,10 +88,6 @@ public abstract class TestGroupsGeneratorTask extends Task {
     public void execute() throws BuildException {
         //  TODO: validate
         final File inputFile = new File(input);
-        if (inputFile == null) {
-            LOGGER.error("input not substituted with configured value");
-            return;
-        }
         if (inputFile.isDirectory()) {
             if(!Strings.isNullOrEmpty(getSpecificationOutput())) {
                 try {

--- a/proctor-builder/pom.xml
+++ b/proctor-builder/pom.xml
@@ -23,11 +23,6 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
-            <artifactId>proctor-consumer</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>${project.groupId}</groupId>
             <artifactId>proctor-store</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/proctor-codegen-test/pom.xml
+++ b/proctor-codegen-test/pom.xml
@@ -29,14 +29,6 @@
                             <goal>generate-test</goal>
                         </goals>
                     </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>${project.groupId}</groupId>
-                <artifactId>proctor-maven-plugin</artifactId>
-                <version>${project.version}</version>
-
-                <executions>
                     <execution>
                         <id>proctor-generate-test-js</id>
                         <goals>
@@ -55,14 +47,45 @@
 
     <dependencies>
         <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>proctor-codegen</artifactId>
-            <version>${project.version}</version>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <scope>test</scope>
         </dependency>
-
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>proctor-common</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>proctor-consumer</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>util-varexport</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.tomcat</groupId>
+            <artifactId>tomcat-servlet-api</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/proctor-codegen/pom.xml
+++ b/proctor-codegen/pom.xml
@@ -22,20 +22,20 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>proctor-consumer</artifactId>
-            <version>${project.version}</version>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.freemarker</groupId>
             <artifactId>freemarker</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/proctor-codegen/src/main/resources/com/indeed/proctor/consumer/ant/groups-manager.ftl
+++ b/proctor-codegen/src/main/resources/com/indeed/proctor/consumer/ant/groups-manager.ftl
@@ -12,7 +12,6 @@ import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Supplier;
 
 

--- a/proctor-codegen/src/main/resources/com/indeed/proctor/consumer/ant/groups.ftl
+++ b/proctor-codegen/src/main/resources/com/indeed/proctor/consumer/ant/groups.ftl
@@ -7,7 +7,6 @@ import com.indeed.proctor.consumer.*;
 import javax.annotation.Nullable;
 import javax.annotation.Nonnull;
 import java.lang.Override;
-import java.util.Map;
 
 /*
  * GENERATED source; do not edit directly

--- a/proctor-codegen/src/main/resources/com/indeed/proctor/consumer/ant/payload.ftl
+++ b/proctor-codegen/src/main/resources/com/indeed/proctor/consumer/ant/payload.ftl
@@ -4,7 +4,6 @@ import com.indeed.proctor.common.model.TestBucket;
 import com.indeed.proctor.consumer.AbstractGroupsPayload;
 
 import javax.annotation.Nullable;
-import javax.annotation.Nonnull;
 
 /*
 * GENERATED source; do not edit directly

--- a/proctor-common/pom.xml
+++ b/proctor-common/pom.xml
@@ -31,7 +31,6 @@
         <dependency>
             <groupId>com.indeed</groupId>
             <artifactId>util-varexport</artifactId>
-            <version>${indeed-util.version}</version>
         </dependency>
 
         <dependency>
@@ -44,8 +43,11 @@
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.5.2</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.findbugs</groupId>
@@ -58,10 +60,6 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-beans</artifactId>
         </dependency>
 
         <dependency>

--- a/proctor-common/src/main/java/com/indeed/proctor/common/ProctorUtils.java
+++ b/proctor-common/src/main/java/com/indeed/proctor/common/ProctorUtils.java
@@ -22,7 +22,6 @@ import com.indeed.proctor.common.model.TestMatrixArtifact;
 import com.indeed.proctor.common.model.TestMatrixDefinition;
 import com.indeed.proctor.common.model.TestMatrixVersion;
 import com.indeed.proctor.common.model.TestType;
-import org.apache.el.ExpressionFactoryImpl;
 import org.apache.log4j.Logger;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -596,7 +595,7 @@ public abstract class ProctorUtils {
     }
 
     public static ProvidedContext convertContextToTestableMap(Map<String,String> providedContext) {
-        final ExpressionFactory expressionFactory = new ExpressionFactoryImpl();
+        final ExpressionFactory expressionFactory = ExpressionFactory.newInstance();
         boolean methodNotFoundException = false;
         Map<String, Object> primitiveVals = new HashMap<String, Object>();
         primitiveVals.put("int", 0);
@@ -655,7 +654,7 @@ public abstract class ProctorUtils {
 
     public static void verifyInternallyConsistentDefinition(final String testName, final String matrixSource, @Nonnull final ConsumableTestDefinition testDefinition, final FunctionMapper functionMapper, final ProvidedContext providedContext) throws IncompatibleTestMatrixException {
         final List<Allocation> allocations = testDefinition.getAllocations();
-        ExpressionFactory expressionFactory = new ExpressionFactoryImpl();
+        ExpressionFactory expressionFactory = ExpressionFactory.newInstance();
         //verify test rule is valid EL
         final String testRule = testDefinition.getRule();
 

--- a/proctor-common/src/main/java/com/indeed/proctor/common/RuleEvaluator.java
+++ b/proctor-common/src/main/java/com/indeed/proctor/common/RuleEvaluator.java
@@ -1,10 +1,7 @@
 package com.indeed.proctor.common;
 
-import com.google.common.base.CharMatcher;
-import com.google.common.base.Strings;
 import com.indeed.proctor.common.el.LibraryFunctionMapperBuilder;
 import com.indeed.proctor.common.el.MulticontextReadOnlyVariableMapper;
-import org.apache.el.ExpressionFactoryImpl;
 import org.apache.log4j.Logger;
 import org.apache.taglibs.standard.functions.Functions;
 
@@ -34,7 +31,7 @@ public class RuleEvaluator {
 
     static final FunctionMapper FUNCTION_MAPPER = defaultFunctionMapperBuilder().build();
 
-    static final ExpressionFactory EXPRESSION_FACTORY = new ExpressionFactoryImpl();
+    static final ExpressionFactory EXPRESSION_FACTORY = ExpressionFactory.newInstance();
 
     @Nonnull
     final ExpressionFactory expressionFactory;

--- a/proctor-common/src/test/java/com/indeed/proctor/common/BenchmarkEl.java
+++ b/proctor-common/src/test/java/com/indeed/proctor/common/BenchmarkEl.java
@@ -17,8 +17,6 @@ import javax.el.MapELResolver;
 import javax.el.ValueExpression;
 import javax.el.VariableMapper;
 
-import org.apache.el.ExpressionFactoryImpl;
-
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 
@@ -26,7 +24,7 @@ public class BenchmarkEl {
     public static void main(final String[] args) {
         final FunctionMapper functionMapper = new LibraryFunctionMapperBuilder().add("proctor", ProctorRuleFunctions.class).build();
 
-        final ExpressionFactory expressionFactory = new ExpressionFactoryImpl();
+        final ExpressionFactory expressionFactory = ExpressionFactory.newInstance();
 
         final CompositeELResolver elResolver = new CompositeELResolver();
         elResolver.add(new ArrayELResolver());

--- a/proctor-common/src/test/java/com/indeed/proctor/common/TestRandomTestChooser.java
+++ b/proctor-common/src/test/java/com/indeed/proctor/common/TestRandomTestChooser.java
@@ -16,7 +16,6 @@ import java.util.Map;
 import javax.el.ExpressionFactory;
 import javax.el.FunctionMapper;
 
-import org.apache.el.ExpressionFactoryImpl;
 import org.junit.Test;
 
 import com.google.common.collect.Lists;
@@ -82,7 +81,7 @@ public class TestRandomTestChooser {
     }
 
     static RandomTestChooser initializeRandomTestChooser(final List<Range> ranges, final List<TestBucket> buckets) {
-        final ExpressionFactory expressionFactory = new ExpressionFactoryImpl();
+        final ExpressionFactory expressionFactory = ExpressionFactory.newInstance();
 
         final FunctionMapper functionMapper = RuleEvaluator.FUNCTION_MAPPER;
 

--- a/proctor-common/src/test/java/com/indeed/proctor/common/TestStandardTestChooser.java
+++ b/proctor-common/src/test/java/com/indeed/proctor/common/TestStandardTestChooser.java
@@ -7,7 +7,6 @@ import com.indeed.proctor.common.model.ConsumableTestDefinition;
 import com.indeed.proctor.common.model.Range;
 import com.indeed.proctor.common.model.TestBucket;
 import com.indeed.proctor.common.model.TestType;
-import org.apache.el.ExpressionFactoryImpl;
 import org.easymock.classextension.EasyMock;
 import org.junit.Assert;
 import org.junit.Before;
@@ -54,7 +53,7 @@ public class TestStandardTestChooser {
 
     @Before
     public void setupMocks() throws Exception {
-        expressionFactory = new ExpressionFactoryImpl();
+        expressionFactory = ExpressionFactory.newInstance();
         functionMapper = RuleEvaluator.FUNCTION_MAPPER;
         testName = "testName";
         testDefinition = new ConsumableTestDefinition();

--- a/proctor-consumer/pom.xml
+++ b/proctor-consumer/pom.xml
@@ -29,8 +29,28 @@
             <type>pom</type>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+        </dependency>
+        <dependency>
             <groupId>commons-lang</groupId>
             <artifactId>commons-lang</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-beans</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>

--- a/proctor-maven-plugin/pom.xml
+++ b/proctor-maven-plugin/pom.xml
@@ -28,6 +28,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>proctor-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
             <artifactId>maven-plugin-annotations</artifactId>
             <version>3.2</version>
@@ -41,6 +46,19 @@
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>
             <version>3.1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-model</artifactId>
+            <version>3.1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
         </dependency>
     </dependencies>
 

--- a/proctor-maven-plugin/src/main/java/com/indeed/proctor/builder/maven/BuilderMojo.java
+++ b/proctor-maven-plugin/src/main/java/com/indeed/proctor/builder/maven/BuilderMojo.java
@@ -8,6 +8,7 @@ import org.apache.maven.plugins.annotations.Parameter;
 
 import java.io.File;
 import java.io.FileWriter;
+import java.io.IOException;
 import java.io.Writer;
 
 @Mojo(name = "generate-matrix")
@@ -32,7 +33,10 @@ public class BuilderMojo extends AbstractMojo {
         }
         try {
             // try to make sure path exists
-            outputFile.getParentFile().mkdirs();
+            final File parent = outputFile.getParentFile();
+            if (!parent.exists() && !parent.mkdirs()) {
+                throw new IOException("Failed to create parent path: " + parent.getPath());
+            }
 
             Writer w = new FileWriter(outputFile);
             new LocalProctorBuilder(topDirectory, w, "".equals(author) ? author : null, version).execute();

--- a/proctor-maven-plugin/src/main/java/com/indeed/proctor/consumer/gen/maven/AbstractJavaProctorMojo.java
+++ b/proctor-maven-plugin/src/main/java/com/indeed/proctor/consumer/gen/maven/AbstractJavaProctorMojo.java
@@ -1,6 +1,7 @@
 package com.indeed.proctor.consumer.gen.maven;
 
 import com.indeed.proctor.consumer.gen.CodeGenException;
+import com.indeed.proctor.consumer.gen.TestGroupsGenerator;
 import com.indeed.proctor.consumer.gen.TestGroupsJavaGenerator;
 
 import java.io.File;
@@ -14,12 +15,14 @@ public abstract class AbstractJavaProctorMojo extends AbstractProctorMojo {
 
     private final TestGroupsJavaGenerator gen = new TestGroupsJavaGenerator();
 
+    @Override
     protected void processFile(final File file, final String packageName, final String className) throws CodeGenException {
         getLog().info(String.format("Building resources for %s", packageName));
         gen.generate(file.getPath(), getOutputDirectory().getPath(), packageName, className, className + "Manager", className + "Context");
     }
 
+    @Override
     protected void generateTotalSpecification(final File parent, final File outputDir) throws CodeGenException {
-        gen.makeTotalSpecification(parent, outputDir.getPath());
+        TestGroupsGenerator.makeTotalSpecification(parent, outputDir.getPath());
     }
 }

--- a/proctor-maven-plugin/src/main/java/com/indeed/proctor/consumer/gen/maven/AbstractJavascriptProctorMojo.java
+++ b/proctor-maven-plugin/src/main/java/com/indeed/proctor/consumer/gen/maven/AbstractJavascriptProctorMojo.java
@@ -1,6 +1,7 @@
 package com.indeed.proctor.consumer.gen.maven;
 
 import com.indeed.proctor.consumer.gen.CodeGenException;
+import com.indeed.proctor.consumer.gen.TestGroupsGenerator;
 import com.indeed.proctor.consumer.gen.TestGroupsJavascriptGenerator;
 import org.apache.maven.plugins.annotations.Parameter;
 
@@ -22,12 +23,14 @@ public abstract class AbstractJavascriptProctorMojo extends AbstractProctorMojo 
         return useClosure;
     }
 
+    @Override
     protected void processFile(final File file, final String packageName, final String className) throws CodeGenException {
         getLog().info(String.format("Building resources for %s", packageName));
         gen.generate(file.getPath(), getOutputDirectory().getPath(), packageName, className, useClosure);
     }
 
+    @Override
     protected void generateTotalSpecification(final File parent, final File outputDir) throws CodeGenException {
-        gen.makeTotalSpecification(parent, outputDir.getPath());
+        TestGroupsGenerator.makeTotalSpecification(parent, outputDir.getPath());
     }
 }

--- a/proctor-maven-plugin/src/main/java/com/indeed/proctor/consumer/gen/maven/AbstractProctorMojo.java
+++ b/proctor-maven-plugin/src/main/java/com/indeed/proctor/consumer/gen/maven/AbstractProctorMojo.java
@@ -5,7 +5,6 @@ import java.io.IOException;
 
 import com.indeed.proctor.common.ProctorUtils;
 import com.indeed.proctor.consumer.gen.CodeGenException;
-import com.indeed.proctor.consumer.gen.TestGroupsGenerator;
 import org.apache.commons.io.filefilter.FileFilterUtils;
 import org.apache.maven.model.Resource;
 import org.apache.maven.plugin.AbstractMojo;
@@ -30,7 +29,7 @@ public abstract class AbstractProctorMojo extends AbstractMojo {
          * attribute)
          */
     private void recursiveSpecificationsFinder(final File dir, final String packageNamePrefix) throws CodeGenException {
-        if (dir.equals(null)) {
+        if (dir == null) {
             throw new CodeGenException("recursiveSpecificationsFinder called with null pointer");
         }
         final File[] files = dir.listFiles();
@@ -58,8 +57,8 @@ public abstract class AbstractProctorMojo extends AbstractMojo {
          * Adds any non partial specifications to resources
          */
     private void addNonPartialsToResources(final File dir, final Resource resource) throws CodeGenException {
-        if (dir.equals(null)) {
-            throw new CodeGenException("Could not read from directory " + dir.getPath());
+        if (dir == null) {
+            throw new CodeGenException("Could not read from directory");
         }
         final File[] files = dir.listFiles();
         if (files == null) {
@@ -84,8 +83,8 @@ public abstract class AbstractProctorMojo extends AbstractMojo {
          */
     void createTotalSpecifications(final File dir, final String packageDirectory) throws MojoExecutionException {
 
-        if (dir.equals(null)) {
-            throw new MojoExecutionException("Could not read from directory " + dir.getPath());
+        if (dir == null) {
+            throw new MojoExecutionException("Could not read from directory");
         }
         final File[] files = dir.listFiles();
         if (files == null) {
@@ -95,16 +94,21 @@ public abstract class AbstractProctorMojo extends AbstractMojo {
         if (providedContextFiles.length == 1) {
             final File parent = providedContextFiles[0].getParentFile();
             final File outputDir = new File(getSpecificationOutput() + File.separator + packageDirectory.substring(0,packageDirectory.lastIndexOf(File.separator)));
-            outputDir.mkdirs();
+            if (!outputDir.exists() && !outputDir.mkdirs()) {
+                throw new MojoExecutionException("Couldn't create directory: " + outputDir.getPath());
+            }
             try {
                 generateTotalSpecification(parent, outputDir);
             } catch (final CodeGenException e) {
                 throw new MojoExecutionException("Couldn't create total specification",e);
             }
         }
-        for (File entry : dir.listFiles()) {
-            if (entry.isDirectory()) {
-                createTotalSpecifications(entry, (packageDirectory == null) ? entry.getName() : packageDirectory + File.separator + entry.getName());
+        final File[] entries = dir.listFiles();
+        if (entries != null) {
+            for (File entry : entries) {
+                if (entry.isDirectory()) {
+                    createTotalSpecifications(entry, (packageDirectory == null) ? entry.getName() : packageDirectory + File.separator + entry.getName());
+                }
             }
         }
     }
@@ -126,11 +130,11 @@ public abstract class AbstractProctorMojo extends AbstractMojo {
         final File specificationOutputDir = getSpecificationOutput();
         resourceGenerated.setDirectory(specificationOutputDir.getPath());
         resourceGenerated.addInclude("**/*.json");
-        final Resource[] resources = {resourceNonGenerated,resourceGenerated};
-        return resources;
+        return new Resource[]{resourceNonGenerated,resourceGenerated};
 
     }
 
+    @Override
     public void execute() throws MojoExecutionException {
         File topDirectory = getTopDirectory();
         if(topDirectory == null) {

--- a/proctor-maven-plugin/src/main/java/com/indeed/proctor/consumer/gen/maven/JavaProctorMojo.java
+++ b/proctor-maven-plugin/src/main/java/com/indeed/proctor/consumer/gen/maven/JavaProctorMojo.java
@@ -18,6 +18,7 @@ public class JavaProctorMojo extends AbstractJavaProctorMojo {
     @Parameter(property = "topDirectory", defaultValue = "${basedir}/src/main/proctor", required = true)
     private File topDirectory;
 
+    @Override
     File getTopDirectory() {
         return topDirectory;
     }
@@ -25,6 +26,7 @@ public class JavaProctorMojo extends AbstractJavaProctorMojo {
     @Parameter(property = "outputDirectory", defaultValue = "${project.build.directory}/generated-sources/proctor", required = true)
     private File outputDirectory;
 
+    @Override
     File getOutputDirectory() {
         return outputDirectory;
     }
@@ -32,6 +34,7 @@ public class JavaProctorMojo extends AbstractJavaProctorMojo {
     @Parameter(property = "specificationOutput", defaultValue = "${project.build.directory}/generated-resources/proctor", required = true)
     private File specificationOutput;
 
+    @Override
     File getSpecificationOutput() {
         return specificationOutput;
     }

--- a/proctor-maven-plugin/src/main/java/com/indeed/proctor/consumer/gen/maven/JavaProctorTestMojo.java
+++ b/proctor-maven-plugin/src/main/java/com/indeed/proctor/consumer/gen/maven/JavaProctorTestMojo.java
@@ -18,6 +18,7 @@ public class JavaProctorTestMojo extends AbstractJavaProctorMojo {
     @Parameter(property = "topDirectory", defaultValue = "${basedir}/src/test/proctor", required = true)
     private File topDirectory;
 
+    @Override
     File getTopDirectory() {
         return topDirectory;
     }
@@ -25,6 +26,7 @@ public class JavaProctorTestMojo extends AbstractJavaProctorMojo {
     @Parameter(property = "outputDirectory", defaultValue = "${project.build.directory}/generated-test-sources/proctor", required = true)
     protected File outputDirectory;
 
+    @Override
     File getOutputDirectory() {
         return outputDirectory;
     }
@@ -32,6 +34,7 @@ public class JavaProctorTestMojo extends AbstractJavaProctorMojo {
     @Parameter(property = "specificationOutput", defaultValue = "${project.build.directory}/generated-test-resources/proctor", required = true)
     private File specificationOutput;
 
+    @Override
     File getSpecificationOutput() {
         return specificationOutput;
     }

--- a/proctor-store-git/pom.xml
+++ b/proctor-store-git/pom.xml
@@ -21,15 +21,34 @@
             <artifactId>proctor-store</artifactId>
             <version>${project.version}</version>
         </dependency>
-
         <dependency>
-            <groupId>com.indeed</groupId>
-            <artifactId>util-varexport</artifactId>
-            <version>${indeed-util.version}</version>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>proctor-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jgit</groupId>

--- a/proctor-store-svn/pom.xml
+++ b/proctor-store-svn/pom.xml
@@ -18,6 +18,11 @@
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>proctor-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>proctor-store</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -25,11 +30,26 @@
         <dependency>
             <groupId>com.indeed</groupId>
             <artifactId>util-varexport</artifactId>
-            <version>${indeed-util.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
         </dependency>
         <dependency>
             <groupId>org.tmatesoft.svnkit</groupId>

--- a/proctor-store/pom.xml
+++ b/proctor-store/pom.xml
@@ -23,13 +23,27 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
-            <artifactId>proctor-consumer</artifactId>
-            <version>${project.version}</version>
+            <artifactId>util-varexport</artifactId>
         </dependency>
-
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/proctor-tomcat-deps-provided/pom.xml
+++ b/proctor-tomcat-deps-provided/pom.xml
@@ -16,31 +16,19 @@
         <developerConnection>${project.parent.scm.developerConnection}</developerConnection>
     </scm>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.indeed</groupId>
+                <artifactId>proctor-tomcat-deps</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
-        <dependency>
-            <groupId>com.indeed</groupId>
-            <artifactId>proctor-tomcat-deps</artifactId>
-            <type>pom</type>
-            <version>${project.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.tomcat</groupId>
-                    <artifactId>tomcat-el-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.tomcat</groupId>
-                    <artifactId>tomcat-jasper-el</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.tomcat</groupId>
-                    <artifactId>tomcat-jsp-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.tomcat</groupId>
-                    <artifactId>tomcat-servlet-api</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
         <dependency>
             <groupId>org.apache.tomcat</groupId>
             <artifactId>tomcat-el-api</artifactId>

--- a/proctor-tomcat-deps/pom.xml
+++ b/proctor-tomcat-deps/pom.xml
@@ -25,12 +25,12 @@
         <dependency>
             <groupId>org.apache.tomcat</groupId>
             <artifactId>tomcat-jasper-el</artifactId>
-            <scope>compile</scope>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.tomcat</groupId>
             <artifactId>tomcat-jsp-api</artifactId>
-            <scope>compile</scope>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.tomcat</groupId>


### PR DESCRIPTION
Update dependencies based on `mvn dependency:analyze` output. Remove
explicit references to tomcat-jasper-el to allow using a different EL
implementation if possible. Move tomcat-jasper-el and tomcat-jsp-api to
runtime scope (they aren't needed for compilation). Move shared
dependencies to parent's `<dependencyManagement>` section. Fix a few
errors in the ant/maven plug-ins.
