### PR TITLE
Remove uses of Guava methods removed in Guava 21.0

### DIFF
--- a/proctor-common/src/main/java/com/indeed/proctor/common/model/TestType.java
+++ b/proctor-common/src/main/java/com/indeed/proctor/common/model/TestType.java
@@ -1,6 +1,5 @@
 package com.indeed.proctor.common.model;
 
-import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
 import com.fasterxml.jackson.core.JsonGenerator;
@@ -31,7 +30,8 @@ public final class TestType implements JsonSerializable {
     @Nonnull
     public static TestType register(@Nonnull final String name) {
         final TestType testType = new TestType(name);
-        return Objects.firstNonNull(TYPES.putIfAbsent(testType.name(), testType), testType);
+        final TestType previous = TYPES.putIfAbsent(testType.name(), testType);
+        return previous != null ? previous : testType;
     }
 
     // Emulate enum

--- a/proctor-consumer/src/main/java/com/indeed/proctor/consumer/AbstractGroups.java
+++ b/proctor-consumer/src/main/java/com/indeed/proctor/consumer/AbstractGroups.java
@@ -1,6 +1,5 @@
 package com.indeed.proctor.consumer;
 
-import com.google.common.base.Objects;
 import com.google.common.collect.Maps;
 import com.indeed.proctor.common.ProctorResult;
 import com.indeed.proctor.common.model.ConsumableTestDefinition;
@@ -119,7 +118,7 @@ public abstract class AbstractGroups {
             }
         }
 
-        return Objects.firstNonNull(payload, Payload.EMPTY_PAYLOAD);
+        return payload != null ? payload : Payload.EMPTY_PAYLOAD;
     }
 
     /**


### PR DESCRIPTION
Fix lost commit, see #20.