### PR TITLE
Add base url to the paths to "ind-eng-logo.png"

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -10,6 +10,9 @@ kramdown:
 
     exclude: ['Gemfile', 'Gemfile.lock', 'Rakefile.rb', 'README.md']
 
+plugins:
+    [jekyll-gist]
+
 # jekyll serve --watch --baseurl=
 # baseurl: "https://indeedeng.github.io/proctor"
 # baseurl: "https://agrover-indeed.github.io/proctor"

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -35,7 +35,7 @@
                                 <span class="icon-bar"></span>
                             </button>
                             <a href="https://engineering.indeedblog.com/" class="navbar-brand">
-                                <img src="images/ind-eng-logo.png" alt="Indeed Engineering" width="300" scale="0">     
+                                <img src="{{ site.baseurl }}/images/ind-eng-logo.png" alt="Indeed Engineering" width="300" scale="0">     
                             </a>             
                         </div>
                         <div id="headerNavLinks" class="collapse navbar-collapse">

--- a/_layouts/release_notes.html
+++ b/_layouts/release_notes.html
@@ -35,7 +35,7 @@
                                 <span class="icon-bar"></span>
                             </button>
                             <a href="https://engineering.indeedblog.com/" class="navbar-brand">
-                                <img src="images/ind-eng-logo.png" alt="Indeed Engineering" width="300" scale="0">     
+                                <img src="{{ site.baseurl }}/images/ind-eng-logo.png" alt="Indeed Engineering" width="300" scale="0">     
                             </a>             
                         </div>
                         <div id="headerNavLinks" class="collapse navbar-collapse">


### PR DESCRIPTION
To load "ind-eng-logo.png" image correctly in the production environment, we need a base URL before the relative path.
In https://opensource.indeedeng.io/proctor, it will be `/proctor`.