### PR TITLE
Remove parent POM reference

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,12 +1,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>com.indeed</groupId>
-        <artifactId>common-parent</artifactId>
-        <version>20</version>
-    </parent>
-
     <prerequisites>
         <maven>3.3.9</maven>
     </prerequisites>


### PR DESCRIPTION
It appears everything in the parent POM that is needed is already replicated or overwritten. Since this is now the only project using it (and [common-parent-pom](https://github.com/indeedeng/common-parent-pom) is already archived), we can remove the reference here.

If for some reason, folks disagree with this change, it's also worth noting that the parent should have been [oss-parent-pom](https://github.com/indeedeng/oss-parent-pom) in the first place anyway.