### PR TITLE
Revert "Remove parent POM reference"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
+    <parent>
+        <groupId>com.indeed</groupId>
+        <artifactId>common-parent</artifactId>
+        <version>20</version>
+    </parent>
+
     <prerequisites>
         <maven>3.3.9</maven>
     </prerequisites>


### PR DESCRIPTION
Reverts indeedeng/proctor#58

Because the proctor library failed to publish by this change, I want to revert this for now.
Here is the failed publishing job: https://github.com/indeedeng/maven-publish/actions/runs/1914581045