### PR TITLE
PROW-2085: update to more friendly error message when promoting incompatible changes with unknown bucket

### DIFF
--- a/proctor-common/src/main/java/com/indeed/proctor/common/ProctorUtils.java
+++ b/proctor-common/src/main/java/com/indeed/proctor/common/ProctorUtils.java
@@ -27,6 +27,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.el.ExpressionFactoryImpl;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.util.Strings;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
@@ -604,9 +605,9 @@ public abstract class ProctorUtils {
             }
 
             if (!unknownBuckets.isEmpty()) {
+                final String bucketString = (unknownBuckets.size() > 1 ? "bucket values: " : "bucket value: ") + Strings.join(unknownBuckets, ',');
                 throw new IncompatibleTestMatrixException(
-                        "Allocation range in " + testName + " from " + matrixSource
-                                + " refers to unknown bucket value(s) " + unknownBuckets + " with length > 0"
+                        "Application test specification does not contain "+ bucketString +". Please update the application test specification first"
                 );
             }
         }

--- a/proctor-common/src/main/java/com/indeed/proctor/common/ProctorUtils.java
+++ b/proctor-common/src/main/java/com/indeed/proctor/common/ProctorUtils.java
@@ -607,7 +607,7 @@ public abstract class ProctorUtils {
             if (!unknownBuckets.isEmpty()) {
                 final String bucketString = (unknownBuckets.size() > 1 ? "bucket values: " : "bucket value: ") + Strings.join(unknownBuckets, ',');
                 throw new IncompatibleTestMatrixException(
-                        "Application test specification does not contain "+ bucketString +". Please update the application test specification first"
+                        "Proctor specification in your application does not contain "+ bucketString +". Please update the proctor specification first"
                 );
             }
         }

--- a/proctor-common/src/test/java/com/indeed/proctor/common/TestProctorUtils.java
+++ b/proctor-common/src/test/java/com/indeed/proctor/common/TestProctorUtils.java
@@ -1864,7 +1864,7 @@ public class TestProctorUtils {
         assertThat(proctorLoadResult.getDynamicTestWithErrors()).containsExactly(TEST_B);
 
         assertThat(proctorLoadResult.getTestErrorMap())
-                .hasEntrySatisfying(TEST_A, x -> assertThat(x).hasMessageContaining("Application test specification does not contain bucket"));
+                .hasEntrySatisfying(TEST_A, x -> assertThat(x).hasMessageContaining("Proctor specification in your application does not contain bucket"));
         assertThat(proctorLoadResult.getDynamicTestErrorMap())
                 .hasEntrySatisfying(TEST_B, x -> assertThat(x)
                         .hasMessageContaining("depends on an unknown or incompatible test")

--- a/proctor-common/src/test/java/com/indeed/proctor/common/TestProctorUtils.java
+++ b/proctor-common/src/test/java/com/indeed/proctor/common/TestProctorUtils.java
@@ -1864,7 +1864,7 @@ public class TestProctorUtils {
         assertThat(proctorLoadResult.getDynamicTestWithErrors()).containsExactly(TEST_B);
 
         assertThat(proctorLoadResult.getTestErrorMap())
-                .hasEntrySatisfying(TEST_A, x -> assertThat(x).hasMessageContaining("unknown bucket"));
+                .hasEntrySatisfying(TEST_A, x -> assertThat(x).hasMessageContaining("Application test specification does not contain bucket"));
         assertThat(proctorLoadResult.getDynamicTestErrorMap())
                 .hasEntrySatisfying(TEST_B, x -> assertThat(x)
                         .hasMessageContaining("depends on an unknown or incompatible test")

--- a/proctor-webapp-library/src/test/java/com/indeed/proctor/webapp/jobs/MatrixCheckerTest.java
+++ b/proctor-webapp-library/src/test/java/com/indeed/proctor/webapp/jobs/MatrixCheckerTest.java
@@ -73,9 +73,8 @@ public class MatrixCheckerTest {
                         stubDefinition(unknownBucketValue)
                 ).getErrors()
         ).containsExactly(
-                "app@v1 cannot load test 'sample_tst':"
-                        + " Allocation range in sample_tst from app@v1 refers to"
-                        + " unknown bucket value(s) [1] with length > 0"
+                "app@v1 cannot load test 'sample_tst': Application test specification does not contain bucket value: 1." +
+                        " Please update the application test specification first"
         );
 
         assertThat(

--- a/proctor-webapp-library/src/test/java/com/indeed/proctor/webapp/jobs/MatrixCheckerTest.java
+++ b/proctor-webapp-library/src/test/java/com/indeed/proctor/webapp/jobs/MatrixCheckerTest.java
@@ -73,8 +73,8 @@ public class MatrixCheckerTest {
                         stubDefinition(unknownBucketValue)
                 ).getErrors()
         ).containsExactly(
-                "app@v1 cannot load test 'sample_tst': Application test specification does not contain bucket value: 1." +
-                        " Please update the application test specification first"
+                "app@v1 cannot load test 'sample_tst': Proctor specification in your application does not contain bucket value: 1." +
+                        " Please update the proctor specification first"
         );
 
         assertThat(


### PR DESCRIPTION
Original message is not intuitive/descriptive enough.
Example: Allocation range in acme_inline_survey_tst from CompatibilityChecker refers to unknown bucket value(s) [5] with length > 0

Updated message: Application test specification does not contain bucket values: 5,6. Please update the application test specification first

