### PR TITLE
add null annotation for model

### DIFF
--- a/proctor-common/src/main/java/com/indeed/proctor/common/TestSpecification.java
+++ b/proctor-common/src/main/java/com/indeed/proctor/common/TestSpecification.java
@@ -16,7 +16,7 @@ public class TestSpecification {
     private Map<String, Integer> buckets = Collections.emptyMap();
     @Nullable
     private PayloadSpecification payload;
-
+    @Nullable
     private String description;
 
     public int getFallbackValue() {


### PR DESCRIPTION
Add `@Nullable` annotation for `TestSpecification` class

`description` field can be null (e.g. `proctor-common/src/test/resources/com/indeed/proctor/common/no-context-specification.json` and specification in `proctor-demo` repository)
