### PR TITLE
PROW-2306: Fix checking all null state to include JSON payloads

### DIFF
--- a/proctor-common/src/main/java/com/indeed/proctor/common/model/Payload.java
+++ b/proctor-common/src/main/java/com/indeed/proctor/common/model/Payload.java
@@ -178,10 +178,8 @@ public class Payload {
     }
     // Sanity check precondition for above setters
     private void precheckStateAllNull() throws IllegalStateException {
-        if ((doubleValue != null) || (doubleArray != null)
-            || (longValue != null) || (longArray != null)
-            || (stringValue != null) || (stringArray != null)
-            || (map != null)) {
+        if (Stream.of(PayloadType.values())
+                .anyMatch(pt -> resolvers.get(pt).apply(this) != null) ) {
             throw new IllegalStateException(PAYLOAD_OVERWRITE_EXCEPTION + this);
         }
     }

--- a/proctor-common/src/test/java/com/indeed/proctor/common/model/TestPayload.java
+++ b/proctor-common/src/test/java/com/indeed/proctor/common/model/TestPayload.java
@@ -35,6 +35,7 @@ public class TestPayload {
     @Test
     public void verifyPayloadSetters() {
         final Map<PayloadType, Payload> payloads = getPayloadTypePayloadSampleMap(0);
+        final ObjectMapper objectMapper = new ObjectMapper();
 
         assertThatThrownBy(() ->
                 payloads.get(PayloadType.DOUBLE_VALUE).setStringArray(new String[]{"foo", "bar", "baz"}))
@@ -56,6 +57,9 @@ public class TestPayload {
                 .isInstanceOf(IllegalStateException.class);
         assertThatThrownBy(() ->
                 payloads.get(PayloadType.MAP).setMap(Collections.<String, Object>emptyMap()))
+                .isInstanceOf(IllegalStateException.class);
+        assertThatThrownBy(() ->
+                payloads.get(PayloadType.JSON).setJson(objectMapper.readTree("{}")))
                 .isInstanceOf(IllegalStateException.class);
     }
 


### PR DESCRIPTION
In JSON PR #78 missed adding JSON payload type to the precheckStateAllNull() function thus allowing a payload to have type JSON and any other type causing an exception in ProctorUtils at verifyInternallyConsistentDefinition()::1171
```java 
if (p.numFieldsDefined() != 1) {
     throw new IncompatibleTestMatrixException("Test " + testName + " from " + matrixSource
               + " has a test bucket payload with multiple types: " + bucket);
}
```
Change allows for future added payload types to be automatically checked. 