### PR TITLE
PROW-2306 Handle Empty Payloads in verify test definition

### DIFF
--- a/proctor-common/src/main/java/com/indeed/proctor/common/ProctorUtils.java
+++ b/proctor-common/src/main/java/com/indeed/proctor/common/ProctorUtils.java
@@ -1168,7 +1168,7 @@ public abstract class ProctorUtils {
         for (final TestBucket bucket : buckets) {
             final Payload p = bucket.getPayload();
             if (p != null) {
-                if (p.numFieldsDefined() != 1) {
+                if (p.numFieldsDefined() > 1) {
                     throw new IncompatibleTestMatrixException(
                             "Test " + testName + " from " + matrixSource
                                     + " has a test bucket payload with multiple types: " + bucket

--- a/proctor-common/src/test/java/com/indeed/proctor/common/TestProctorUtils.java
+++ b/proctor-common/src/test/java/com/indeed/proctor/common/TestProctorUtils.java
@@ -532,6 +532,27 @@ public class TestProctorUtils {
             );
             /* Should ignore checking failure because time was not instantiated */
         }
+        {
+            final ConsumableTestDefinition testDef = constructDefinition(
+                    fromCompactBucketFormat(
+                            "inactive:-1,control:0,test:1",
+                            Payload.EMPTY_PAYLOAD,
+                            Payload.EMPTY_PAYLOAD,
+                            Payload.EMPTY_PAYLOAD
+                    ),
+                    fromCompactAllocationFormat("${time.yes eq 'SP'}|-1:0.5,0:0.5,1:0.0", "-1:0.25,0:0.5,1:0.25")
+            );
+            final Map<String, String> providedContextNoClass = new HashMap<>();
+            providedContextNoClass.put("time", "com.indeed.proctor.common.NotFoundClass");
+            final ProvidedContext providedContext = convertContextToTestableMap(providedContextNoClass);
+            assertTrue(providedContext.shouldEvaluate());
+            verifyInternallyConsistentDefinition(
+                    "testProvidedContextConversion",
+                    "test Provided Context Conversion Class",
+                    testDef,
+                    providedContext
+            );
+        }
     }
 
     @Test

--- a/proctor-common/src/test/resources/com/indeed/proctor/common/unrecognized-payload-test-matrix.json
+++ b/proctor-common/src/test/resources/com/indeed/proctor/common/unrecognized-payload-test-matrix.json
@@ -1,0 +1,55 @@
+{
+  "audit" : {
+    "version" : "1524",
+    "updated" : 1313525000000,
+    "updatedDate" : "2011-08-16T15:03-0500",
+    "updatedBy" : "shoichi"
+  },
+  "tests" : {
+    "exampletst" : {
+      "constants" : {
+        "ENGLISH" : "en"
+      },
+      "version" : "1",
+      "salt" : "exampletst",
+      "rule" : null,
+      "buckets" : [ {
+        "name" : "control",
+        "value" : 0,
+        "payload" : {
+          "UNRECOGNIZED" : "notrealpayloadtype"
+        }
+      }, {
+        "name" : "test",
+        "value" : 1,
+        "payload" : {
+          "UNRECOGNIZED" : "notrealpayloadtype"
+        }
+      } ],
+      "allocations" : [ {
+        "rule" : "${lang == ENGLISH}",
+        "ranges" : [ {
+          "bucketValue" : 0,
+          "length" : 0.25
+        }, {
+          "bucketValue" : 1,
+          "length" : 0.75
+        } ],
+        "id" : ""
+      }, {
+        "rule" : null,
+        "ranges" : [ {
+          "bucketValue" : 0,
+          "length" : 0.1
+        }, {
+          "bucketValue" : 1,
+          "length" : 0.9
+        } ],
+        "id" : ""
+      } ],
+      "silent" : false,
+      "testType" : "USER",
+      "description" : "An example test"
+    }
+  }
+}


### PR DESCRIPTION
Handle empty payloads to prevent future failures loading test definitions/matrices with unrecognized payload