### PR TITLE
PROC-1265: Optimize out allocs in rule validation

### DIFF
--- a/proctor-common/src/main/java/com/indeed/proctor/common/RuleEvaluator.java
+++ b/proctor-common/src/main/java/com/indeed/proctor/common/RuleEvaluator.java
@@ -130,11 +130,11 @@ public class RuleEvaluator {
             LOGGER.error("Invalid rule '" +  rule + "'");   //  TODO: should this be an exception?
             return false;
         }
-        final String bareRule = ProctorUtils.removeElExpressionBraces(rule);
-        if (StringUtils.isBlank(bareRule) || "true".equalsIgnoreCase(bareRule)) {
+        final ProctorUtils.ElExpressionClassification ec = ProctorUtils.clasifyElExpression(rule, true);
+        if (ec == ProctorUtils.ElExpressionClassification.EMPTY || ec == ProctorUtils.ElExpressionClassification.CONSTANT_TRUE) {
             return true;    //  always passes
         }
-        if ("false".equalsIgnoreCase(bareRule)) {
+        if (ec == ProctorUtils.ElExpressionClassification.CONSTANT_FALSE) {
             return false;
         }
 

--- a/proctor-common/src/main/java/com/indeed/proctor/common/RuleVerifyUtils.java
+++ b/proctor-common/src/main/java/com/indeed/proctor/common/RuleVerifyUtils.java
@@ -15,7 +15,7 @@ import javax.el.ValueExpression;
 import java.util.List;
 import java.util.Set;
 
-import static com.indeed.proctor.common.ProctorUtils.removeElExpressionBraces;
+import static com.indeed.proctor.common.ProctorUtils.isEmptyElExpression;
 import static com.indeed.proctor.common.RuleEvaluator.checkRuleIsBooleanType;
 
 public class RuleVerifyUtils {
@@ -36,8 +36,7 @@ public class RuleVerifyUtils {
             final ELContext elContext,
             final Set<String> absentIdentifiers
     ) throws InvalidRuleException {
-        final String bareRule = removeElExpressionBraces(testRule);
-        if (!StringUtils.isBlank(bareRule)) {
+        if (!isEmptyElExpression(testRule)) {
             final ValueExpression valueExpression;
             try {
                 valueExpression = expressionFactory.createValueExpression(elContext, testRule, Boolean.class);

--- a/proctor-common/src/test/java/com/indeed/proctor/common/TestProctorUtils.java
+++ b/proctor-common/src/test/java/com/indeed/proctor/common/TestProctorUtils.java
@@ -36,6 +36,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static com.indeed.proctor.common.ProctorUtils.convertContextToTestableMap;
+import static com.indeed.proctor.common.ProctorUtils.isEmptyElExpression;
 import static com.indeed.proctor.common.ProctorUtils.isEmptyWhitespace;
 import static com.indeed.proctor.common.ProctorUtils.readSpecification;
 import static com.indeed.proctor.common.ProctorUtils.removeElExpressionBraces;
@@ -239,6 +240,25 @@ public class TestProctorUtils {
         assertEquals("${lang == 'en'", removeElExpressionBraces("${lang == 'en'"));
         // mis matched braces are not handled
         assertEquals("lang == 'en'}", removeElExpressionBraces("lang == 'en'}"));
+    }
+
+    @Test
+    public void testIsEmptyElExpression() {
+        assertTrue(isEmptyElExpression(""));
+        assertTrue(isEmptyElExpression(" "));
+        assertTrue(isEmptyElExpression(null));
+        assertTrue(isEmptyElExpression("\t"));
+        assertTrue(isEmptyElExpression(" ${} "));
+        assertTrue(isEmptyElExpression(" ${ } "));
+
+        assertFalse(isEmptyElExpression("${a}"));
+        assertFalse(isEmptyElExpression(" ${a} "));
+        assertFalse(isEmptyElExpression(" ${ a } "));
+        assertFalse(isEmptyElExpression(" ${ a}"));
+        assertFalse(isEmptyElExpression("${a } "));
+        assertFalse(isEmptyElExpression(" a "));
+        assertFalse(isEmptyElExpression("lang == 'en'"));
+        assertFalse(isEmptyElExpression("${lang == 'en'}"));
     }
 
     @Test

--- a/proctor-common/src/test/java/com/indeed/proctor/common/TestStandardTestChooser.java
+++ b/proctor-common/src/test/java/com/indeed/proctor/common/TestStandardTestChooser.java
@@ -21,6 +21,7 @@ import javax.el.ValueExpression;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.function.BiConsumer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
@@ -200,6 +201,31 @@ public class TestStandardTestChooser {
         assertNull( "Expected no allocation to be found ", chooseResult.getAllocation());
 
         EasyMock.verify(ruleEvaluator);
+    }
+
+    @Test
+    public void testEvaluateBooleanRuleWithValueExpr() {
+        final BiConsumer<String, Boolean> assertEvaluatesTo = (rule, value) -> {
+            final RuleEvaluator evaluator = new RuleEvaluator(
+                ExpressionFactory.newInstance(),
+                RuleEvaluator.FUNCTION_MAPPER,
+                Collections.emptyMap());
+            final boolean result = evaluator.evaluateBooleanRuleWithValueExpr(rule, Collections.emptyMap());
+            assertEquals(value, result);
+        };
+
+        // fast-track
+        assertEvaluatesTo.accept("", true);
+        assertEvaluatesTo.accept("${}", true);
+        assertEvaluatesTo.accept("${    }", true);
+        assertEvaluatesTo.accept("${true}", true);
+        assertEvaluatesTo.accept("${TrUe}", true);
+        assertEvaluatesTo.accept("${false}", false);
+        assertEvaluatesTo.accept("${faLsE}", false);
+
+        // slow-track
+        assertEvaluatesTo.accept("${1 == 0}", false);
+        assertEvaluatesTo.accept("${1 == 1}", true);
     }
 
     @Test


### PR DESCRIPTION
Validate rules are not empty with no heap allocations. Fast-track constant rules evaluation with no heap allocations.