### PR TITLE
EEX-149 Add isDynamic flag to ConsumableTestDefinition

### DIFF
--- a/proctor-common/src/main/java/com/indeed/proctor/common/dynamic/MetaTagsFilter.java
+++ b/proctor-common/src/main/java/com/indeed/proctor/common/dynamic/MetaTagsFilter.java
@@ -27,7 +27,9 @@ public class MetaTagsFilter implements DynamicFilter {
 
     @Override
     public boolean matches(final String testName, final ConsumableTestDefinition testDefinition) {
-        return testDefinition.getMetaTags().stream().anyMatch(this.metaTags::contains);
+        boolean isMatched = testDefinition.getMetaTags().stream().anyMatch(this.metaTags::contains);
+        testDefinition.setDynamic(isMatched);
+        return isMatched;
     }
 
     @Override

--- a/proctor-common/src/main/java/com/indeed/proctor/common/dynamic/TestNamePatternFilter.java
+++ b/proctor-common/src/main/java/com/indeed/proctor/common/dynamic/TestNamePatternFilter.java
@@ -46,7 +46,9 @@ public class TestNamePatternFilter implements DynamicFilter {
     @Override
     public boolean matches(
             @Nullable final String testName, final ConsumableTestDefinition testDefinition) {
-        return !Strings.isNullOrEmpty(testName) && pattern.matcher(testName).matches();
+        boolean isMatched = !Strings.isNullOrEmpty(testName) && pattern.matcher(testName).matches();
+        testDefinition.setDynamic(isMatched);
+        return isMatched;
     }
 
     @Override

--- a/proctor-common/src/main/java/com/indeed/proctor/common/dynamic/TestNamePrefixFilter.java
+++ b/proctor-common/src/main/java/com/indeed/proctor/common/dynamic/TestNamePrefixFilter.java
@@ -37,7 +37,9 @@ public class TestNamePrefixFilter implements DynamicFilter {
     @Override
     public boolean matches(
             @Nullable final String testName, final ConsumableTestDefinition testDefinition) {
-        return !Strings.isNullOrEmpty(testName) && testName.startsWith(prefix);
+        boolean isMatched = !Strings.isNullOrEmpty(testName) && testName.startsWith(prefix);
+        testDefinition.setDynamic(isMatched);
+        return isMatched;
     }
 
     @Override

--- a/proctor-common/src/main/java/com/indeed/proctor/common/model/ConsumableTestDefinition.java
+++ b/proctor-common/src/main/java/com/indeed/proctor/common/model/ConsumableTestDefinition.java
@@ -31,6 +31,7 @@ public class ConsumableTestDefinition {
 
     /** @see TestDefinition#getDependsOn() */
     @Nullable private TestDependency dependsOn;
+    private boolean isDynamic = false;
 
     public ConsumableTestDefinition() {
         /* intentionally empty */
@@ -204,6 +205,14 @@ public class ConsumableTestDefinition {
 
     public boolean getSilent() {
         return silent;
+    }
+
+    public void setDynamic(final boolean dynamic) {
+        this.isDynamic = dynamic;
+    }
+
+    public boolean getDynamic() {
+        return isDynamic;
     }
 
     @Nonnull

--- a/proctor-common/src/test/java/com/indeed/proctor/common/dynamic/TestMetaTagsFilter.java
+++ b/proctor-common/src/test/java/com/indeed/proctor/common/dynamic/TestMetaTagsFilter.java
@@ -67,6 +67,7 @@ public class TestMetaTagsFilter {
                         testMetaTags);
 
         assertEquals(expected, filter.matches("", definition));
+        assertEquals(expected, definition.getDynamic());
     }
 
     @Test

--- a/proctor-common/src/test/java/com/indeed/proctor/common/dynamic/TestTestNamePatternFilter.java
+++ b/proctor-common/src/test/java/com/indeed/proctor/common/dynamic/TestTestNamePatternFilter.java
@@ -12,10 +12,17 @@ public class TestTestNamePatternFilter {
     @Test
     public void testPrefixPattern() {
         final TestNamePatternFilter filter = new TestNamePatternFilter("abc_.*");
-        assertTrue(filter.matches("abc_something", new ConsumableTestDefinition()));
+
+        ConsumableTestDefinition testDefinition1 = new ConsumableTestDefinition();
+        assertTrue(filter.matches("abc_something", testDefinition1));
+        assertTrue(testDefinition1.getDynamic());
+
         assertTrue(filter.matches("abc_", new ConsumableTestDefinition()));
         assertFalse(filter.matches("_abc_", new ConsumableTestDefinition()));
-        assertFalse(filter.matches("abc", new ConsumableTestDefinition()));
+
+        ConsumableTestDefinition testDefinition2 = new ConsumableTestDefinition();
+        assertFalse(filter.matches("abc", testDefinition2));
+        assertFalse(testDefinition2.getDynamic());
     }
 
     @Test

--- a/proctor-common/src/test/java/com/indeed/proctor/common/dynamic/TestTestNamePrefixFilter.java
+++ b/proctor-common/src/test/java/com/indeed/proctor/common/dynamic/TestTestNamePrefixFilter.java
@@ -11,10 +11,17 @@ public class TestTestNamePrefixFilter {
     @Test
     public void testPrefixPattern() {
         final TestNamePrefixFilter filter = new TestNamePrefixFilter("abc_");
-        assertTrue(filter.matches("abc_", new ConsumableTestDefinition()));
+
+        ConsumableTestDefinition testDefinition1 = new ConsumableTestDefinition();
+        assertTrue(filter.matches("abc_", testDefinition1));
+        assertTrue(testDefinition1.getDynamic());
+
         assertTrue(filter.matches("abc_something", new ConsumableTestDefinition()));
         assertFalse(filter.matches(" abc_something", new ConsumableTestDefinition()));
+
+        ConsumableTestDefinition testDefinition2 = new ConsumableTestDefinition();
         assertFalse(filter.matches("abc", new ConsumableTestDefinition()));
+        assertFalse(testDefinition2.getDynamic());
     }
 
     @Test


### PR DESCRIPTION
Add isDynamic flag to ConsumableTestDefinition. This will enable us to exclude dynamic tests in exposure logging to reduce the data volume and avoid over logging