### PR TITLE
EEX-153 add a hasLogged flag in ConsumableTestDefinition

### DIFF
--- a/proctor-common/src/main/java/com/indeed/proctor/common/model/ConsumableTestDefinition.java
+++ b/proctor-common/src/main/java/com/indeed/proctor/common/model/ConsumableTestDefinition.java
@@ -32,6 +32,7 @@ public class ConsumableTestDefinition {
     /** @see TestDefinition#getDependsOn() */
     @Nullable private TestDependency dependsOn;
     private boolean isDynamic = false;
+    private boolean hasLogged = false;
 
     public ConsumableTestDefinition() {
         /* intentionally empty */
@@ -213,6 +214,12 @@ public class ConsumableTestDefinition {
 
     public boolean getDynamic() {
         return isDynamic;
+    }
+    public void setHasLogged(final boolean hasLogged) {
+        this.isDynamic = hasLogged;
+    }
+    public boolean getHasLogged() {
+        return hasLogged;
     }
 
     @Nonnull


### PR DESCRIPTION
Add a hasLogged flag in ConsumableTestDefinition to track whether a test has logged or not. This can prevent over logging.