### PR TITLE
EEX-153 add hashset to ProctorResult to keep track logged tests

### DIFF
--- a/proctor-common/src/main/java/com/indeed/proctor/common/ProctorResult.java
+++ b/proctor-common/src/main/java/com/indeed/proctor/common/ProctorResult.java
@@ -7,11 +7,7 @@ import com.indeed.proctor.common.model.TestBucket;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.SortedMap;
-import java.util.TreeMap;
+import java.util.*;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySortedMap;
@@ -42,6 +38,8 @@ public class ProctorResult {
     private final Identifiers identifiers;
 
     private final Map<String, Object> inputContext;
+
+    private final HashSet<Integer> hasLoggedTests;
 
     /**
      * Create a ProctorResult with copies of the provided collections
@@ -143,6 +141,7 @@ public class ProctorResult {
         this.testDefinitions = testDefinitions;
         this.identifiers = identifiers;
         this.inputContext = inputContext;
+        this.hasLoggedTests = new HashSet<>();
     }
 
     /**
@@ -192,5 +191,9 @@ public class ProctorResult {
     @Nonnull
     public Map<String, Object> getInputContext() {
         return inputContext;
+    }
+
+    public boolean markTestAsLogged(int testHash) {
+        return this.hasLoggedTests.add(testHash);
     }
 }

--- a/proctor-common/src/main/java/com/indeed/proctor/common/ProctorResult.java
+++ b/proctor-common/src/main/java/com/indeed/proctor/common/ProctorResult.java
@@ -198,7 +198,7 @@ public class ProctorResult {
         return inputContext;
     }
 
-    public boolean markTestAsLogged(String testHash) {
-        return this.hasLoggedTests.add(testHash);
+    public boolean markTestAsLogged(String test) {
+        return this.hasLoggedTests.add(test);
     }
 }

--- a/proctor-common/src/main/java/com/indeed/proctor/common/ProctorResult.java
+++ b/proctor-common/src/main/java/com/indeed/proctor/common/ProctorResult.java
@@ -7,7 +7,12 @@ import com.indeed.proctor.common.model.TestBucket;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.*;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.HashSet;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySortedMap;

--- a/proctor-common/src/main/java/com/indeed/proctor/common/ProctorResult.java
+++ b/proctor-common/src/main/java/com/indeed/proctor/common/ProctorResult.java
@@ -198,7 +198,7 @@ public class ProctorResult {
         return inputContext;
     }
 
-    public boolean markTestAsLogged(String test) {
+    public boolean markTestAsLogged(final String test) {
         return this.hasLoggedTests.add(test);
     }
 }

--- a/proctor-common/src/main/java/com/indeed/proctor/common/ProctorResult.java
+++ b/proctor-common/src/main/java/com/indeed/proctor/common/ProctorResult.java
@@ -7,12 +7,7 @@ import com.indeed.proctor.common.model.TestBucket;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.SortedMap;
-import java.util.TreeMap;
-import java.util.HashSet;
+import java.util.*;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySortedMap;
@@ -44,7 +39,7 @@ public class ProctorResult {
 
     private final Map<String, Object> inputContext;
 
-    private final HashSet<Integer> hasLoggedTests;
+    private final HashSet<String> hasLoggedTests;
 
     /**
      * Create a ProctorResult with copies of the provided collections
@@ -198,7 +193,7 @@ public class ProctorResult {
         return inputContext;
     }
 
-    public boolean markTestAsLogged(int testHash) {
+    public boolean markTestAsLogged(String testHash) {
         return this.hasLoggedTests.add(testHash);
     }
 }

--- a/proctor-common/src/main/java/com/indeed/proctor/common/model/ConsumableTestDefinition.java
+++ b/proctor-common/src/main/java/com/indeed/proctor/common/model/ConsumableTestDefinition.java
@@ -32,7 +32,6 @@ public class ConsumableTestDefinition {
     /** @see TestDefinition#getDependsOn() */
     @Nullable private TestDependency dependsOn;
     private boolean isDynamic = false;
-    private boolean hasLogged = false;
 
     public ConsumableTestDefinition() {
         /* intentionally empty */
@@ -214,12 +213,6 @@ public class ConsumableTestDefinition {
 
     public boolean getDynamic() {
         return isDynamic;
-    }
-    public void setHasLogged(final boolean hasLogged) {
-        this.hasLogged = hasLogged;
-    }
-    public boolean getHasLogged() {
-        return hasLogged;
     }
 
     @Nonnull


### PR DESCRIPTION
1. Remove hasLogged flag in ConsumableTestDefinition
2. Add Hashset To ProctorResult