### PR TITLE
EEX-148 Clean up ExposureLogger in AbstractGroupsManager

### DIFF
--- a/proctor-consumer/src/main/java/com/indeed/proctor/consumer/AbstractGroupsManager.java
+++ b/proctor-consumer/src/main/java/com/indeed/proctor/consumer/AbstractGroupsManager.java
@@ -9,10 +9,7 @@ import com.indeed.proctor.common.ProctorResult;
 import com.indeed.proctor.common.model.Audit;
 import com.indeed.proctor.common.model.TestBucket;
 import com.indeed.proctor.common.model.TestType;
-import com.indeed.proctor.consumer.logging.ExposureLogger;
 
-import javax.annotation.CheckForNull;
-import javax.annotation.Nullable;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.util.Collection;
@@ -33,13 +30,10 @@ import static java.util.Collections.emptySortedMap;
 public abstract class AbstractGroupsManager implements ProctorContextDescriptor {
     private final Supplier<Proctor> proctorSource;
     private final Supplier<GroupsManagerInterceptor> interceptorSupplier;
-    @CheckForNull
-    private final ExposureLogger exposureLogger;
 
     protected AbstractGroupsManager(final Supplier<Proctor> proctorSource) {
         this.proctorSource = proctorSource;
         this.interceptorSupplier = GroupsManagerInterceptor::getDefault;
-        this.exposureLogger = null;
     }
 
     protected AbstractGroupsManager(
@@ -47,21 +41,6 @@ public abstract class AbstractGroupsManager implements ProctorContextDescriptor 
             final Supplier<GroupsManagerInterceptor> interceptorSupplier) {
         this.proctorSource = proctorSource;
         this.interceptorSupplier = interceptorSupplier;
-        this.exposureLogger = null;
-    }
-
-    protected AbstractGroupsManager(
-            final Supplier<Proctor> proctorSource,
-            final Supplier<GroupsManagerInterceptor> interceptorSupplier,
-            @Nullable final ExposureLogger exposureLogger
-    ) {
-        this.proctorSource = proctorSource;
-        if (interceptorSupplier != null) {
-            this.interceptorSupplier = interceptorSupplier;
-        } else {
-            this.interceptorSupplier = GroupsManagerInterceptor::getDefault;
-        }
-        this.exposureLogger = exposureLogger;
     }
 
     /**
@@ -158,9 +137,6 @@ public abstract class AbstractGroupsManager implements ProctorContextDescriptor 
                 proctor.determineTestGroups(
                         identifiers, context, forceGroupsOptions, testNameFilter);
         interceptor.afterDetermineGroups(proctorResult);
-        if (this.exposureLogger != null) {
-            this.exposureLogger.logExposureInfo(proctorResult);
-        }
         return proctorResult;
     }
 

--- a/proctor-consumer/src/main/java/com/indeed/proctor/consumer/logging/ExposureLogger.java
+++ b/proctor-consumer/src/main/java/com/indeed/proctor/consumer/logging/ExposureLogger.java
@@ -5,6 +5,4 @@ import com.indeed.proctor.common.ProctorResult;
 public interface ExposureLogger {
 
     void logExposureInfo(ProctorResult proctorResult, String testName);
-
-    void logExposureInfo(ProctorResult proctorResult);
 }


### PR DESCRIPTION
We have moved ExposureLogger to AbstractGroups. The code inside AbstractGroupsManager is no longer needed