### PR TITLE
PROC-1346: Handle Unitless Allocation Edge case

### DIFF
--- a/proctor-common/src/main/java/com/indeed/proctor/common/Proctor.java
+++ b/proctor-common/src/main/java/com/indeed/proctor/common/Proctor.java
@@ -342,9 +342,7 @@ public class Proctor {
         final Set<TestType> testTypesWithInvalidIdentifier = new HashSet<>();
         for (final TestType testType : identifiers.getAvailableTestTypes()) {
             final String identifier = identifiers.getIdentifier(testType);
-            if (identifier == null) {
-                testTypesWithInvalidIdentifier.add(testType);
-            } else if (!identifierValidator.validate(testType, identifier)) {
+            if ((identifier != null) && !identifierValidator.validate(testType, identifier)) {
                 final String invalidIdentifierMessage =
                         String.format(
                                 "An invalid identifier '%s' for test type '%s'"
@@ -380,13 +378,7 @@ public class Proctor {
                     containsUnitlessAllocations ? VALUE_EXPRESSION_TRUE : VALUE_EXPRESSION_FALSE);
             final TestType testType = testChooser.getTestDefinition().getTestType();
             if (testChooser instanceof UnitlessTestChooser) {
-                identifier =
-                        identifiers.getIdentifier(testType) == null
-                                        && testChooser
-                                                .getTestDefinition()
-                                                .getContainsUnitlessAllocation()
-                                ? ""
-                                : identifiers.getIdentifier(testType);
+                identifier = identifiers.getIdentifier(testType);
             } else if (testChooser instanceof StandardTestChooser) {
                 if (testTypesWithInvalidIdentifier.contains(testType)) {
                     invalidIdentifierCount.put(

--- a/proctor-common/src/main/java/com/indeed/proctor/common/Proctor.java
+++ b/proctor-common/src/main/java/com/indeed/proctor/common/Proctor.java
@@ -342,7 +342,9 @@ public class Proctor {
         final Set<TestType> testTypesWithInvalidIdentifier = new HashSet<>();
         for (final TestType testType : identifiers.getAvailableTestTypes()) {
             final String identifier = identifiers.getIdentifier(testType);
-            if ((identifier != null) && !identifierValidator.validate(testType, identifier)) {
+            if (identifier == null) {
+                testTypesWithInvalidIdentifier.add(testType);
+            } else if (!identifierValidator.validate(testType, identifier)) {
                 final String invalidIdentifierMessage =
                         String.format(
                                 "An invalid identifier '%s' for test type '%s'"

--- a/proctor-common/src/main/java/com/indeed/proctor/common/UnitlessTestChooser.java
+++ b/proctor-common/src/main/java/com/indeed/proctor/common/UnitlessTestChooser.java
@@ -37,6 +37,10 @@ public class UnitlessTestChooser extends StandardTestChooser {
             @Nonnull final ForceGroupsOptions forceGroupsOptions,
             @Nonnull final Set<TestType> testTypesWithInvalidIdentifier,
             final boolean isRandomEnabled) {
+        // null is not valid identifier for unitless
+        if (identifier == null) {
+            return Result.EMPTY;
+        }
         return super.choose(identifier, localContext, testGroups, forceGroupsOptions);
     }
 }


### PR DESCRIPTION
Case where a test has multiple rules with missingExperimentalUnit and !missingExperimentalUnit and null identifier was being not handled correctly due to misunderstanding on null identifier case. 